### PR TITLE
파일 업로드 및 네이버 감정 분석 AI 연동 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,8 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb:3.0.5")
     implementation("org.springframework.boot:spring-boot-starter-data-redis:3.0.5")
+    implementation("org.springframework.boot:spring-boot-starter-webflux:3.0.5")
+
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web:3.0.5")
     implementation("org.springframework.boot:spring-boot-starter-validation:3.0.5")
@@ -34,6 +36,9 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4")
+    implementation("com.amazonaws:aws-java-sdk-s3:1.12.435")
+    implementation("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
+
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/com/beside/daldal/config/AwsS3Config.kt
+++ b/src/main/kotlin/com/beside/daldal/config/AwsS3Config.kt
@@ -1,0 +1,34 @@
+package com.beside.daldal.config
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class AwsS3Config {
+    @Value("\${ncp.endpoint}")
+    private lateinit var endPoint: String
+
+    @Value("\${ncp.region}")
+    private lateinit var regionName: String
+
+    @Value("\${ncp.accesskey}")
+    private lateinit var accessKey: String
+
+    @Value("\${ncp.secretkey}")
+    private lateinit var secretKey: String
+
+    @Bean
+    fun amazonS3(): AmazonS3 {
+        return AmazonS3ClientBuilder.standard()
+            .withEndpointConfiguration(AwsClientBuilder.EndpointConfiguration(endPoint, regionName))
+            .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKey, secretKey)))
+            .build()
+    }
+}

--- a/src/main/kotlin/com/beside/daldal/config/WebClientConfig.kt
+++ b/src/main/kotlin/com/beside/daldal/config/WebClientConfig.kt
@@ -1,0 +1,11 @@
+package com.beside.daldal.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfig {
+    @Bean
+    fun webClient(): WebClient = WebClient.create()
+}

--- a/src/main/kotlin/com/beside/daldal/domain/image/error/ImageDeleteFailException.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/image/error/ImageDeleteFailException.kt
@@ -1,0 +1,13 @@
+package com.beside.daldal.domain.image.error
+
+import com.beside.daldal.shared.exception.dto.DaldalRuntimeException
+import com.beside.daldal.shared.exception.dto.ErrorCode
+
+class ImageDeleteFailException : DaldalRuntimeException(
+    ErrorCode(
+        message = "이미지를 삭제하는 도중 문제가 발생했습니다.",
+        status = 500,
+        code = "IMAGE_DELETE_FAIL"
+    )
+) {
+}

--- a/src/main/kotlin/com/beside/daldal/domain/image/error/ImageUploadFailException.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/image/error/ImageUploadFailException.kt
@@ -1,0 +1,13 @@
+package com.beside.daldal.domain.image.error
+
+import com.beside.daldal.shared.exception.dto.DaldalRuntimeException
+import com.beside.daldal.shared.exception.dto.ErrorCode
+
+class ImageUploadFailException : DaldalRuntimeException(
+    ErrorCode(
+        message = "이미지를 업로드 하는 도중에 문제가 발생했습니다.",
+        status = 500,
+        code = "IMAGE_UPLOAD_FAIL"
+    )
+) {
+}

--- a/src/main/kotlin/com/beside/daldal/domain/image/service/ImageService.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/image/service/ImageService.kt
@@ -1,0 +1,51 @@
+package com.beside.daldal.domain.image.service
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
+import com.beside.daldal.domain.image.error.ImageDeleteFailException
+import com.beside.daldal.domain.image.error.ImageUploadFailException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class ImageService(private val s3: AmazonS3) {
+    @Value("\${ncp.bucket.name}")
+    private lateinit var bucketName: String
+
+    @Value("\${ncp.bucket.host}")
+    private lateinit var bucketHost: String
+
+    fun upload(
+        multipartFile: MultipartFile,
+        prefix: String = ""
+    ): String {
+        try {
+            val originalName = "$prefix/${multipartFile.originalFilename}" // 파일 이름
+            val size = multipartFile.size // 파일 크기
+            val objectMetaData = ObjectMetadata()
+            objectMetaData.contentType = multipartFile.contentType
+            objectMetaData.contentLength = size
+            s3.putObject(
+                PutObjectRequest("daldal-bucket", originalName, multipartFile.inputStream, objectMetaData)
+                    .withCannedAcl(CannedAccessControlList.PublicRead)
+            )
+            return "$bucketHost/$bucketName/$originalName"
+        } catch (e: Exception) {
+            throw ImageUploadFailException()
+        }
+    }
+
+    fun delete(
+        filename: String,
+        prefix: String
+    ) {
+        try {
+            s3.deleteObject(bucketName, "$prefix/$filename")
+        } catch (e: Exception) {
+            throw ImageDeleteFailException()
+        }
+    }
+}

--- a/src/main/kotlin/com/beside/daldal/domain/sentiment/dto/SentimentRequest.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/sentiment/dto/SentimentRequest.kt
@@ -1,0 +1,10 @@
+package com.beside.daldal.domain.sentiment.dto
+
+import com.beside.daldal.domain.sentiment.error.SentimentMaxLengthException
+
+
+data class SentimentRequest(val content: String) {
+    init {
+        if (content.length > 1000) throw SentimentMaxLengthException()
+    }
+}

--- a/src/main/kotlin/com/beside/daldal/domain/sentiment/dto/SentimentResponse.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/sentiment/dto/SentimentResponse.kt
@@ -1,0 +1,19 @@
+package com.beside.daldal.domain.sentiment.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SentimentResponse(
+    val document: Document
+)
+
+class Document(
+    val sentiment: String,
+    val confidence: Confidence
+)
+
+class Confidence(
+    val negative: Double,
+    val positive: Double,
+    val neutral: Double,
+)

--- a/src/main/kotlin/com/beside/daldal/domain/sentiment/error/SentimentAnalyzeFailException.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/sentiment/error/SentimentAnalyzeFailException.kt
@@ -1,0 +1,13 @@
+package com.beside.daldal.domain.sentiment.error
+
+import com.beside.daldal.shared.exception.dto.DaldalRuntimeException
+import com.beside.daldal.shared.exception.dto.ErrorCode
+
+class SentimentAnalyzeFailException:DaldalRuntimeException(
+    ErrorCode(
+        message = "감정 분석 도중 문제가 발행했습니다.",
+        code = "SENTIMENT_ANALYZE_ERROR",
+        status = 500
+    )
+) {
+}

--- a/src/main/kotlin/com/beside/daldal/domain/sentiment/error/SentimentMaxLengthException.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/sentiment/error/SentimentMaxLengthException.kt
@@ -1,0 +1,13 @@
+package com.beside.daldal.domain.sentiment.error
+
+import com.beside.daldal.shared.exception.dto.DaldalRuntimeException
+import com.beside.daldal.shared.exception.dto.ErrorCode
+
+class SentimentMaxLengthException:DaldalRuntimeException(
+    ErrorCode(
+        message = "1000자를 초과할 수 없습니다.",
+        code = "SENTIMENT_MAX_LENGTH",
+        status = 400
+    )
+) {
+}

--- a/src/main/kotlin/com/beside/daldal/domain/sentiment/service/SentimentService.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/sentiment/service/SentimentService.kt
@@ -1,0 +1,37 @@
+package com.beside.daldal.domain.sentiment.service
+
+import com.beside.daldal.domain.sentiment.dto.Document
+import com.beside.daldal.domain.sentiment.dto.SentimentRequest
+import com.beside.daldal.domain.sentiment.dto.SentimentResponse
+import com.beside.daldal.domain.sentiment.error.SentimentAnalyzeFailException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+@Service
+class SentimentService(
+    private val webClient: WebClient
+) {
+    val url = "https://naveropenapi.apigw.ntruss.com/sentiment-analysis/v1/analyze"
+
+    @Value("\${sentiment.clientKey}")
+    private lateinit var clientKey: String
+    @Value("\${sentiment.secretKey}")
+    private lateinit var secretKey: String
+
+    fun analyze(content: String): Document {
+        val res = webClient.post()
+            .uri(url)
+            .headers { headers ->
+                headers["X-NCP-APIGW-API-KEY-ID"] = clientKey
+                headers["X-NCP-APIGW-API-KEY"] = secretKey
+            }
+            .bodyValue(SentimentRequest(content))
+            .retrieve()
+            .toEntity(SentimentResponse::class.java)
+            .block()
+            ?.body ?: throw SentimentAnalyzeFailException()
+
+        return res.document
+    }
+}


### PR DESCRIPTION
- ncp를 이용한 네이터 클라우드 이미지 upload, delete 연동 작업 완료
- ncp를 이용한 텍스트 감정 분석 api 연동 완료

ncp s3의 경우 aws sdk 모듈을 그대로 사용할 수 있도록 구현되어 있기 때문에 의존성이 aws로 들어갑니다.
비밀 키의 경우 돈과 직접적인 연관이 있기 때문에 조심해야합니다.