### PR TITLE
리뷰 수정 API에서 이미지 파일을 보내지 않는 경우 기존의 이미지를 사용하도록 수정 및 이미지 삭제 버그 수정

### DIFF
--- a/src/main/kotlin/com/beside/daldal/domain/review/controller/ReviewController.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/review/controller/ReviewController.kt
@@ -184,10 +184,14 @@ class ReviewController(
         principal: Principal,
         @PathVariable reviewId: String,
         @RequestPart("dto") dto: ReviewUpdateDTO,
-        @RequestPart("file") file: MultipartFile
+        @RequestPart("file") file: MultipartFile?
     ): ResponseEntity<ReviewDTO> {
         val email = principal.name
-        return ResponseEntity.ok(reviewService.updateReview(email, reviewId, dto, file))
+        return if(file != null){
+            ResponseEntity.ok(reviewService.updateReview(email, reviewId, dto, file))
+        }else{
+            ResponseEntity.ok(reviewService.updateReview(email, reviewId, dto))
+        }
     }
 
     @Operation(

--- a/src/main/kotlin/com/beside/daldal/domain/review/entity/Review.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/review/entity/Review.kt
@@ -24,7 +24,7 @@ class Review(
         deletedAt = LocalDateTime.now()
     }
 
-    fun update(content: String, features: List<ReviewFeature>, imageUrl: String, sentiment: ReviewSentiment) {
+    fun update(content: String, features: List<ReviewFeature>, imageUrl: String = this.imageUrl, sentiment: ReviewSentiment) {
         this.content = content
         this.features = features
         this.imageUrl = imageUrl


### PR DESCRIPTION
리뷰 수정 API에서 이미지를 매번 다시 보내야하는 불편함이 있는데 이를 이미지를 보내지 않았을 경우 기존의 업로드된 이미지를 사용하도록 수정했습니다.
또한 이미지 수정 프로세스에서 감정 분석 과정에서 예외가 발생하면 이미지는 업로드되지만 값은 저장되지 않는 버그가 발생하기 때문에 해당 프로세스의 순서를 수정했습니다.