### PR TITLE
코스, 사용자 정보도 리뷰 조회에서 같이 들어가도록 endpoint 변경

### DIFF
--- a/src/main/kotlin/com/beside/daldal/domain/course/dto/CourseReadDTO.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/course/dto/CourseReadDTO.kt
@@ -10,6 +10,7 @@ class CourseReadDTO(
     val name: String,
     var distance: Long,// m 단위
     var duration: Long,
+    var bookamark : Long,
     var points: List<Map<String, Any?>>,
 ) : Serializable {
     companion object {
@@ -19,6 +20,7 @@ class CourseReadDTO(
                 name = entity.name,
                 distance = entity.distance,
                 duration = entity.duration,
+                bookamark =  entity.bookmark,
                 points = entity.points,
             )
         }

--- a/src/main/kotlin/com/beside/daldal/domain/review/controller/ReviewController.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/review/controller/ReviewController.kt
@@ -149,20 +149,29 @@ class ReviewController(
         @RequestPart("dto") dto: ReviewCreateDTO,
         @RequestPart("file") file: MultipartFile
     ): ResponseEntity<ReviewDTO> {
-        println(dto)
+        logger.info("$dto")
         return ResponseEntity.ok(reviewService.createReview(principal.name, courseId, dto, file))
     }
 
 
     @PostMapping("/{courseId}", consumes = ["multipart/form-data"])
-    fun createReviewWithModelAttribute(
+    fun createReviewOrigin(
         principal: Principal,
         @PathVariable courseId: String,
-        @ModelAttribute root: ReviewCreateRootDTO
+        @RequestPart("dto") dto: ReviewCreateDTO,
+        @RequestPart("file") file: MultipartFile
     ): ResponseEntity<ReviewDTO> {
-        logger.info("${root}")
-        return ResponseEntity.ok(reviewService.createReview(principal.name, courseId, root.dto!!, root.file!!))
+        logger.info("$dto")
+        return ResponseEntity.ok(reviewService.createReview(principal.name, courseId, dto, file))
     }
+//    fun createReviewWithModelAttribute(
+//        principal: Principal,
+//        @PathVariable courseId: String,
+//        @ModelAttribute root: ReviewCreateRootDTO
+//    ): ResponseEntity<ReviewDTO> {
+//        logger.info("${root}")
+//        return ResponseEntity.ok(reviewService.createReview(principal.name, courseId, root.dto!!, root.file!!))
+//    }
 
 
     @Operation(

--- a/src/main/kotlin/com/beside/daldal/domain/review/dto/ReviewReadDTO.kt
+++ b/src/main/kotlin/com/beside/daldal/domain/review/dto/ReviewReadDTO.kt
@@ -1,41 +1,48 @@
 package com.beside.daldal.domain.review.dto
 
 import com.beside.daldal.domain.comment.dto.CommentDTO
+import com.beside.daldal.domain.course.dto.CourseReadDTO
 import com.beside.daldal.domain.course.entity.Course
+import com.beside.daldal.domain.member.dto.MemberReadDTO
 import com.beside.daldal.domain.member.entity.Member
 import com.beside.daldal.domain.review.entity.Review
+import com.beside.daldal.domain.review.entity.ReviewFeature
 import com.beside.daldal.domain.review.entity.ReviewSentiment
 import com.beside.daldal.domain.review.error.ReviewNotFoundException
+import com.fasterxml.jackson.annotation.JsonFormat
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
 
 class ReviewReadDTO(
     val id: String,
-    val memberId: String,
-    val courseId: String,
+    val member: MemberReadDTO,
+    val course : CourseReadDTO,
     val content: String,
     val imageUrl: String,
     val favourite: Long,
-    val bookmark: Long,
     val sentiment: ReviewSentiment,
     val isFavorite: Boolean,
     val isBookmarked: Boolean,
-    val features: List<String>,
-    val comments: List<CommentDTO>
+    val features: List<ReviewFeature>,
+    val comments: List<CommentDTO>,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", shape =JsonFormat.Shape.STRING, timezone = "Asia/Seoul")
+    val createAt : LocalDateTime?
 ) {
     companion object {
-        fun from(review: Review, course: Course, member: Member): ReviewReadDTO {
+        fun from(review: Review, course: Course, me: Member, creator : Member): ReviewReadDTO {
             return ReviewReadDTO(
                 id = review.id ?: throw ReviewNotFoundException(),
-                memberId = review.memberId,
-                courseId = review.courseId,
+                member = MemberReadDTO.from(creator),
+                course = CourseReadDTO.from(course),
                 content = review.content,
                 favourite = review.favorite,
                 sentiment = review.sentiment,
-                features = review.features.map { it.name },
-                bookmark = course.bookmark,
+                features = review.features,
                 imageUrl = review.imageUrl,
-                isFavorite = review.id in member.favorite,
-                isBookmarked = course.id in member.bookmarked,
-                comments = review.comments.map { CommentDTO.from(it) }
+                isFavorite = review.id in me.favorite,
+                isBookmarked = course.id in me.bookmarked,
+                comments = review.comments.map { CommentDTO.from(it) },
+                createAt = review.createdAt
             )
         }
     }


### PR DESCRIPTION
### 문제 상황
- 프론트에서 리뷰를 조회하면 memberId, courseId만 조회되기 때문에 불필요한 api call이 많아진다.


### 해결방법
- 리뷰 조회시 사용자의 정보도 같이 전달